### PR TITLE
Add --ecc-output=PATH option to choose output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ premake5 --config=release ecc
 Careful! `config` option case sensitive! If there is no config passed via
 command line, module will choose the default one. 
 
+### Custom output directory
+
+By default the file is written next to your `premake5.lua`. Override
+the destination with the `--ecc-output=PATH` option:
+
+```
+premake5 --ecc-output=/path/to/output ecc
+```
+
+This is useful when `premake5.lua` does not live at the location where
+the language server expects to find `compile_commands.json`.
+
 Note: if you want to embed this module into your premake build follow
 the [manual](https://premake.github.io/docs/Embedding-Modules/)
 

--- a/_preload.lua
+++ b/_preload.lua
@@ -7,6 +7,12 @@
 		description = "Select config for export compile_commands.json"
 	}
 
+	newoption {
+		trigger = "ecc-output",
+		value = "PATH",
+		description = "Directory to write compile_commands.json (default: _MAIN_SCRIPT_DIR)"
+	}
+
 	newaction {
 		trigger         = "ecc",
 		shortname       = "Export compile commands",
@@ -24,8 +30,7 @@
 		end,
 
 		execute = function()
-			local dir = {}
-			dir.location = _MAIN_SCRIPT_DIR
+			local dir = { location = _OPTIONS["ecc-output"] or _MAIN_SCRIPT_DIR }
 			p.generate(dir, "compile_commands.json", p.modules.ecc.generateFile)
 		end
 	}


### PR DESCRIPTION
Without the option, behavior is unchanged (writes to _MAIN_SCRIPT_DIR). Useful when premake5.lua does not live at the location where the language server expects to find compile_commands.json.