### PR TITLE
Fix json escaping and flag paths

### DIFF
--- a/ecc.lua
+++ b/ecc.lua
@@ -42,14 +42,42 @@
 		end
 	end
 
+	-- Flags premake's toolsets emit as "<flag> <path>" in a single string. In a
+	-- Makefile that's fine — the shell re-tokenizes — but compile_commands.json
+	-- treats each array entry as one verbatim argv slot, so clangd otherwise looks
+	-- up a path that begins with a literal space. Split these into two tokens.
+	local two_token_flags = {
+		["-isystem"] = true,
+		["-iquote"] = true,
+		["-iframework"] = true,
+		["-isysroot"] = true,
+		["-include"] = true,
+		["-imacros"] = true,
+		["-idirafter"] = true,
+	}
+
+	local function jsonEscape(s)
+		-- Escape backslashes first so existing escapes (e.g. -DVERSION=\"x.y.z\")
+		-- aren't double-mangled when we then escape the embedded quotes.
+		return s:gsub("\\", "\\\\"):gsub("\"", "\\\"")
+	end
+
 	function m.writeArgs(args, obj, src)
 		for _,arg in ipairs(args) do
 			-- Defines like the following will break JSON format, quotes need to be escaped
 			-- -DEXPORT_API=__attribute__((visibility("default")))
-			-- Escape backslashes first so existing escapes (e.g. -DVERSION=\"x.y.z\")
-			-- aren't double-mangled when we then escape the embedded quotes.
-			local escaped = arg:gsub("\\", "\\\\"):gsub("\"", "\\\"")
-			p.w("\"%s\",", escaped)
+			local space_idx = arg:find(" ", 1, true)
+			local first = space_idx and arg:sub(1, space_idx - 1) or nil
+			if first and two_token_flags[first] then
+				local rest = arg:sub(space_idx + 1)
+				if #rest >= 2 and rest:sub(1, 1) == "\"" and rest:sub(-1) == "\"" then
+					rest = rest:sub(2, -2)
+				end
+				p.w("\"%s\",", first)
+				p.w("\"%s\",", jsonEscape(rest))
+			else
+				p.w("\"%s\",", jsonEscape(arg))
+			end
 		end
 		p.w("\"-c\",")
 		p.w("\"-o\",")

--- a/ecc.lua
+++ b/ecc.lua
@@ -27,14 +27,17 @@
 			local cfg = m.getConfig(prj)
 			local args = m.getArguments(prj, cfg)
 			local files = table.shallowcopy(prj._.files)
+			-- "directory" must be a path that exists on disk so clangd can chdir
+			-- there. prj.location is often a virtual workspace path that hasn't
+			-- been created on disk; fall back to where we're writing the JSON.
+			local outdir = path.getabsolute(_OPTIONS["ecc-output"] or _MAIN_SCRIPT_DIR)
 			for i,node in ipairs(files) do
-				local output = cfg.objdir .. "/" ..  node.objname .. ".o"
-				local obj = path.getrelative(prj.location, output)
+				local output = path.getabsolute(cfg.objdir .. "/" ..  node.objname .. ".o")
 				p.push("{")
 				p.push("\"arguments\": [")
-				m.writeArgs(args, obj, node.relpath)
+				m.writeArgs(args, prj.location, output, node.abspath)
 				p.pop("],")
-				p.w("\"directory\": \"%s\",", prj.location)
+				p.w("\"directory\": \"%s\",", outdir)
 				p.w("\"file\": \"%s\",", node.abspath)
 				p.w("\"output\": \"%s\"", output)
 				p.pop("},")
@@ -62,7 +65,16 @@
 		return s:gsub("\\", "\\\\"):gsub("\"", "\\\"")
 	end
 
-	function m.writeArgs(args, obj, src)
+	-- Resolve a path that premake authored relative to `base` to an absolute
+	-- path so clangd doesn't need a particular CWD to find it.
+	local function absPath(base, rel)
+		if path.isabsolute(rel) then
+			return rel
+		end
+		return path.getabsolute(path.join(base, rel))
+	end
+
+	function m.writeArgs(args, base, obj, src)
 		for _,arg in ipairs(args) do
 			-- Defines like the following will break JSON format, quotes need to be escaped
 			-- -DEXPORT_API=__attribute__((visibility("default")))
@@ -74,7 +86,9 @@
 					rest = rest:sub(2, -2)
 				end
 				p.w("\"%s\",", first)
-				p.w("\"%s\",", jsonEscape(rest))
+				p.w("\"%s\",", jsonEscape(absPath(base, rest)))
+			elseif arg:sub(1, 2) == "-I" and #arg > 2 then
+				p.w("\"-I%s\",", jsonEscape(absPath(base, arg:sub(3))))
 			else
 				p.w("\"%s\",", jsonEscape(arg))
 			end
@@ -82,7 +96,7 @@
 		p.w("\"-c\",")
 		p.w("\"-o\",")
 		p.w("\"%s\",", obj)
-		p.w("\"%s\"", src)
+		p.w("\"%s\"", jsonEscape(src))
 	end
 
 	function m.getConfig(prj)

--- a/ecc.lua
+++ b/ecc.lua
@@ -46,7 +46,9 @@
 		for _,arg in ipairs(args) do
 			-- Defines like the following will break JSON format, quotes need to be escaped
 			-- -DEXPORT_API=__attribute__((visibility("default")))
-			local escaped = arg:gsub("\"", "\\\"")
+			-- Escape backslashes first so existing escapes (e.g. -DVERSION=\"x.y.z\")
+			-- aren't double-mangled when we then escape the embedded quotes.
+			local escaped = arg:gsub("\\", "\\\\"):gsub("\"", "\\\"")
 			p.w("\"%s\",", escaped)
 		end
 		p.w("\"-c\",")


### PR DESCRIPTION
Three fixes that together let clangd actually load and use the generated `compile_commands.json` on a real-world project. Split into three commits so each can be reviewed (or reverted) independently.

## 1. Backslashes weren't escaped before quotes

`arg:gsub("\"", "\\\"")` only escapes `"`, but premake passes through args that already contain literal `\"` pairs (e.g. `-DVERSION=\"x.y.z\"` from a generated source file). The current code emits `\\\"...\\\"` in the JSON, which is malformed:

```
YAML:76294:21: error: Expected , between entries!
      "-DVERSION=\\"0.5.7.34\\"",
```

clangd then refuses to load the database entirely:

```
Failed to load compilation database from .../compile_commands.json: Missing key: "file".
```

Fix: escape backslashes first, then quotes, so existing `\"` survives the JSON escape unchanged.

## 2. `-isystem <path>` was emitted as a single argv slot

Premake's toolsets format include flags as `"-isystem <path>"` in one string because Makefiles re-tokenize via the shell. `compile_commands.json` doesn't — each array entry is one verbatim argv slot — so clangd ends up looking up a path that begins with a literal space and silently fails to find every `-isystem` include. Same problem applies to `-iquote`, `-iframework`, `-isysroot`, `-include`, `-imacros`, `-idirafter`.

Fix: when an arg starts with one of those flags followed by a space, split it into two JSON tokens, stripping any surrounding quotes premake added around the path.

## 3. Relative paths anchored to a `directory` that doesn't exist

`directory` was set to `prj.location`, which is the workspace location — may be a virtual path that hasn't actually been created on disk. clangd needs to `chdir` there to resolve relative path args (`-I`, `-isystem`, `-o` target, source file). On Linux it sometimes worked by accident if the user happened to launch from a CWD where the relative paths resolved; on Windows there's no fallback and clangd fails with `'file not found'` on every include and `VFS: failed to set CWD` spam.

Fix: set `directory` to a path that always exists (the `--ecc-output` dir, or `_MAIN_SCRIPT_DIR` — the place where the JSON is being written, which by definition exists), and emit absolute paths for everything that was previously relative against `prj.location`: `file` (already absolute via `node.abspath`), `output`, `-I<path>`, two-token flag paths, the `-o` target, and the source arg. Resolution is now launch-dir and editor independent.
