### PR TITLE
Fix --config option in workspaces that use platforms

### DIFF
--- a/ecc.lua
+++ b/ecc.lua
@@ -57,13 +57,21 @@
 
 	function m.getConfig(prj)
 		local ocfg = _OPTIONS.config
-		local cfg = {}
-		if ocfg and prj.configs[ocfg] then
-			cfg = prj.configs[ocfg]
-		else
-			cfg = m.defaultconfig(prj)
+		if ocfg then
+			-- prj.configs is keyed by "<buildcfg>|<platform>", not bare buildcfg.
+			-- Walk eachconfig and prefer an entry on the workspace defaultplatform.
+			local match
+			for cfg in project.eachconfig(prj) do
+				if cfg.buildcfg == ocfg then
+					if cfg.platform == prj.workspace.defaultplatform then
+						return cfg
+					end
+					match = match or cfg
+				end
+			end
+			if match then return match end
 		end
-		return cfg
+		return m.defaultconfig(prj)
 	end
 
 	function m.getArguments(prj, cfg)


### PR DESCRIPTION
## Bug

`m.getConfig` looks up the requested config with `prj.configs[ocfg]`, where `ocfg` is the bare name passed to `--config=` (e.g. `"Release"`). But `prj.configs` is keyed by `"<buildcfg>|<platform>"` (e.g. `"Release|x64"`) on any workspace that declares `platforms { ... }`. The lookup always misses, ecc silently falls back to `defaultconfig` (Debug), and `--config=` is effectively ignored.

The fallback is silent — ecc produces a `compile_commands.json` regardless — so this is easy to miss unless you compare the resulting flags to what you asked for. I only noticed because some build configs in our project gate through `*Debug`/`*Release` filters, and the counts didn't change when I switched `--config=`.

## Fix

Walk `project.eachconfig(prj)` and match `cfg.buildcfg`, preferring an entry whose `cfg.platform` matches the workspace `defaultplatform`. Falls back to `m.defaultconfig` only when no buildcfg matches.

## Compatibility

**Workspaces without `platforms { ... }`:** unchanged. Premake assigns each config a `nil` platform and `prj.workspace.defaultplatform` is also `nil`, so `cfg.platform == prj.workspace.defaultplatform` is true on the first iteration. Same outcome as the old code path, just reached differently.

**Workspaces with platforms:** `--config=Release` now picks `Release|<defaultplatform>` instead of falling through to Debug.

**One edge case worth flagging:** if anyone was working around the existing bug by passing the composite key directly — e.g. `--config="Release|x64"` — the old code would happen to find it because that's how `prj.configs` is keyed, and the new code won't (it matches `cfg.buildcfg`, which is just `Release`). That's an undocumented workaround for the bug being fixed, and it contradicts the README's `--config=release` example, so I don't think it's a real regression — but want to flag it in case anyone relies on it.

---

Heads up — this is the third PR I've sent your way today (the others added `--ecc-output=PATH` and fixed JSON escaping / single-token `-isystem` paths). I know the project isn't super active and I don't want to flood you; happy for these to sit until you have time, and feel free to merge / decline / cherry-pick whichever pieces seem useful. Thanks for the module either way!